### PR TITLE
Fix setting loading

### DIFF
--- a/GenerateProjects.py
+++ b/GenerateProjects.py
@@ -1,7 +1,9 @@
 import sublime, sublime_plugin
 import os, json
 
-settings = sublime.load_settings('GenerateProjects.sublime-settings')
+def plugin_loaded():
+    global settings
+    settings = sublime.load_settings('GenerateProjects.sublime-settings')
 
 class GenerateProjectsCommand(sublime_plugin.WindowCommand):
 


### PR DESCRIPTION
Settings are loaded too early, causing issue https://github.com/drmonkeyninja/sublime-text-generate-projects/issues/1.

From https://www.sublimetext.com/docs/api_reference.html:

> If a plugin defines a module level function plugin_loaded(), this will be called when the API is ready to use.

@drmonkeyninja @kemko